### PR TITLE
feat: dev component with vue-cli-plugin-lbhc and import it from npm

### DIFF
--- a/front-end/h5/package.json
+++ b/front-end/h5/package.json
@@ -13,6 +13,7 @@
     "engine:build": "PAGE=ENGINE vue-cli-service build --target lib --name engine ./src/engine-entry.js"
   },
   "dependencies": {
+    "@luban-h5/lbc-button": "^0.0.2",
     "@luban-h5/lbs-text-align": "^0.0.3",
     "animate.css": "^3.7.2",
     "ant-design-vue": "^1.3.14",

--- a/front-end/h5/src/mixins/load-plugins.js
+++ b/front-end/h5/src/mixins/load-plugins.js
@@ -1,5 +1,5 @@
 import Vue from 'vue'
-import LbpButton from '../components/plugins/lbp-button'
+import LbpButton from '@luban-h5/lbc-button'
 import LbpPicture from '../components/plugins/lbp-picture'
 import LbpVideo from '../components/plugins/lbp-video'
 import LbpText from '../components/plugins/lbp-text'

--- a/front-end/h5/yarn.lock
+++ b/front-end/h5/yarn.lock
@@ -740,6 +740,17 @@
     cssnano-preset-default "^4.0.0"
     postcss "^7.0.0"
 
+"@luban-h5/lbc-button@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.npmjs.org/@luban-h5/lbc-button/-/lbc-button-0.0.2.tgz#76a2d2567eacc31ab8faa8dcff7fa0dd5202512b"
+  integrity sha512-IzSTxhh9wKExvZklvD4QR6pJu1aBil8lw/B0XzSg+OVfSczXi+tbP1CNWNXmlZHf5pIKfiONIanVB0pkW+j6QA==
+  dependencies:
+    "@luban-h5/lbs-text-align" "^0.0.3"
+    ant-design-vue "^1.2.4"
+    core-js "^3.3.2"
+    font-awesome "4.7.0"
+    vue "^2.6.10"
+
 "@luban-h5/lbs-text-align@^0.0.3":
   version "0.0.3"
   resolved "https://registry.npmjs.org/@luban-h5/lbs-text-align/-/lbs-text-align-0.0.3.tgz#b25a66ad846ee2530e7519c691f74d3c51c352fd"
@@ -1429,6 +1440,40 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
+ant-design-vue@^1.2.4:
+  version "1.4.4"
+  resolved "https://registry.npm.taobao.org/ant-design-vue/download/ant-design-vue-1.4.4.tgz#e3950489324a870273928ed22f5dabf6284424a7"
+  integrity sha1-45UEiTJKhwJzko7SL12r9ihEJKc=
+  dependencies:
+    "@ant-design/icons" "^2.1.1"
+    "@ant-design/icons-vue" "^2.0.0"
+    add-dom-event-listener "^1.0.2"
+    array-tree-filter "^2.1.0"
+    async-validator "^3.0.3"
+    babel-helper-vue-jsx-merge-props "^2.0.3"
+    babel-runtime "6.x"
+    classnames "^2.2.5"
+    component-classes "^1.2.6"
+    dom-align "^1.7.0"
+    dom-closest "^0.2.0"
+    dom-scroll-into-view "^1.2.1"
+    enquire.js "^2.1.6"
+    intersperse "^1.0.0"
+    is-negative-zero "^2.0.0"
+    ismobilejs "^0.5.1"
+    json2mq "^0.2.0"
+    lodash "^4.17.5"
+    moment "^2.21.0"
+    mutationobserver-shim "^0.3.2"
+    node-emoji "^1.10.0"
+    omit.js "^1.0.0"
+    raf "^3.4.0"
+    resize-observer-polyfill "^1.5.1"
+    shallow-equal "^1.0.0"
+    shallowequal "^1.0.2"
+    vue-ref "^1.0.4"
+    warning "^3.0.0"
+
 ant-design-vue@^1.3.14:
   version "1.3.14"
   resolved "https://registry.npm.taobao.org/ant-design-vue/download/ant-design-vue-1.3.14.tgz#4bef079ec7a74e79a20c5c4fab7b0ab7fb3568fc"
@@ -1670,6 +1715,11 @@ async-validator@^1.8.2:
   integrity sha1-I3A7GXQHIdiO28tjEPbXRdqewQk=
   dependencies:
     babel-runtime "6.x"
+
+async-validator@^3.0.3:
+  version "3.2.0"
+  resolved "https://registry.npm.taobao.org/async-validator/download/async-validator-3.2.0.tgz#fcbd644e7b5b7c9304d29a4752c3f06214ef0d56"
+  integrity sha1-/L1kTntbfJME0ppHUsPwYhTvDVY=
 
 async-validator@~1.8.1:
   version "1.8.5"


### PR DESCRIPTION
#!zh:使用vue-cli-plugin-lbhc preset 快速开发组件,将其发布至npm,在鲁班核心模块中import
#!en:use vue-cli-plugin-lbhc preset to develop components quickly and publish it to npm, and you can import the component from npm in luban-h5-core-editor

## reference:
[vue-cli-plugin-lbhc](https://github.com/luban-h5/vue-cli-plugin-lbhc) 
[luban-h5-component-button](https://github.com/luban-h5-components/lbc-button)