### PR TITLE
修复当v-line和h-line显示时，滚动条显示出来的问题

### DIFF
--- a/front-end/h5/src/components/core/styles/align-guides.scss
+++ b/front-end/h5/src/components/core/styles/align-guides.scss
@@ -6,7 +6,7 @@
 // 垂直对齐参考线
 .v-line {
   position: absolute;
-  height: 100vh;
+  height: 100%;
   width: 1px;
   top: 0;
   background-color: #94f5ff;
@@ -16,7 +16,7 @@
 .h-line {
   position: absolute;
   height: 1px;
-  width: 100vh;
+  width: 100%;
   left: 0;
   background-color: #94f5ff;
 }


### PR DESCRIPTION
### 问题描述：
    
因为对齐线长宽比较大，当v-line和h-line显示, 会导致滚动条显示出来。当用户在拖拽组件的时候，会导致滚动条不时的就显示出来，导致页面左右抖动，体验较差。

### 修复方式：

因为对齐线只需要在视图内使用， 故可以把对齐线的长度缩放到视图内，从而避免滚动条的出现。

