### PR TITLE
feat(prop): add visible config

### DIFF
--- a/front-end/h5/src/components/core/editor/edit-panel/props.js
+++ b/front-end/h5/src/components/core/editor/edit-panel/props.js
@@ -138,7 +138,13 @@ export default {
           {
             Object
               .entries(props)
-              .filter(([propKey, propConfig]) => propConfig.visible && propConfig.editor && !propConfig.editor.custom)
+              .filter(([propKey, propConfig]) => {
+                // 1. 如果开发者给 某个prop 显式指定了 visible 属性，则取开发者指定的值；
+                // 2. 否则取默认值：true，即默认在属性面板显示该属性
+                // 3. 组件的某些属性是不需要显示在 配置编辑器的，比如：editorMode(编辑模式/预览模式)，因为这个是鲁班编辑器默认注入到每个组件的，无须显示出来
+                const isVisible = propConfig.hasOwnProperty('visible') ? propConfig.visible : true
+                return isVisible && propConfig.editor && !propConfig.editor.custom
+              })
               .map(([propKey, propConfig]) => this.renderPropFormItem(h, { propKey, propConfig }))
           }
         </a-form>


### PR DESCRIPTION
add visible config for prop, sample

```
color: {
  type: String,
  visible: true, // here
  editor: {
    type: 'el-color-picker',
    defaultValue: '#fff'
  }
}
```

!#en: you can config whether show the prop in props config editor


!#zh:
1. 如果开发者给 某个prop 显式指定了 visible 属性，则取开发者指定的值；
2. 否则取默认值：true，即默认在属性面板显示该属性
3. 组件的某些属性是不需要显示在 配置编辑器的，比如：editorMode(编辑模式/预览模式)，因为这个是鲁班编辑器默认注入到每个组件的，无须显示出来