### PR TITLE
feat: contextmenu support whitelist !#zh: 右键菜单支持元素黑白名单

### DIFF
--- a/front-end/h5/src/locales/lang/en-US.js
+++ b/front-end/h5/src/locales/lang/en-US.js
@@ -60,7 +60,9 @@ export default {
         moveToTop: 'Move To Top',
         moveToBottom: 'Move To Bottom',
         moveUp: 'Move Up',
-        moveDown: 'Move Down'
+        moveDown: 'Move Down',
+        showOnlyButton: 'showOnlyButton',
+        showExcludePicture: 'showExcludePicture'
       }
     },
     fixedTool: {

--- a/front-end/h5/src/locales/lang/zh-CN.js
+++ b/front-end/h5/src/locales/lang/zh-CN.js
@@ -69,7 +69,9 @@ export default {
         moveToTop: '置顶',
         moveToBottom: '置底',
         moveUp: '上移',
-        moveDown: '下移'
+        moveDown: '下移',
+        showOnlyButton: '只有按钮才显示该选项',
+        showExcludePicture: '除了图片都显示该选项'
       }
     },
     fixedTool: {


### PR DESCRIPTION


```js
/**
  * 做一下扩展，提供：黑白名单，来针对某些特定组件，展示特定右键菜单
  * TODO：后期提供如下方式，来扩展右键菜单
        window.GlobalLuban.contextmenu.registerMenu({
          label: '复制',
          value: 'copy',
          elementWhiteList: Array || RegExp
          elementBlackList: Array || RegExp
        })
 */
// 垂直菜单
const contextmenuOptions = [
  {
    i18nLabel: 'editor.centerPanel.contextMenu.copy',
    label: '复制',
    value: 'copy'
  },
  {
    i18nLabel: 'editor.centerPanel.contextMenu.delete',
    label: '删除',
    value: 'delete'
  },
  /**
   * contextMenu 白名单，只有匹配白名单列表里的元素，才会显示该选项
   * 支持正则、数组
   * 数组：[ElementName]
   * 正则：RegExp
   */
  {
    i18nLabel: 'editor.centerPanel.contextMenu.showOnlyButton',
    label: 'showOnlyButton',
    value: 'showOnlyButton',
    elementWhiteList: ['lbp-button']
  },
  /**
   * contextMenu 黑名单，在黑名单列表里的元素，不会显示该选项
   * 支持正则、数组
   * 数组：[ElementName]
   * 正则：RegExp
   */
  {
    i18nLabel: 'editor.centerPanel.contextMenu.showExcludePicture',
    label: 'showExcludePicture',
    value: 'showExcludePicture',
    elementBlackList: /^lbp-picture/
  }
]

```