### PR TITLE
Fix cdn.jsdelivr.net access issue by switching to unpkg.com

### DIFF
--- a/back-end/h5-api/views/engine.ejs
+++ b/back-end/h5-api/views/engine.ejs
@@ -19,16 +19,16 @@
   <meta content="black" name="apple-mobile-web-app-status-bar-style">
   <meta content="telephone=no" name="format-detection">
   <meta content="email=no" name="format-detection">
-  <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/vuex/dist/vuex.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/animate.css@4.1.1/animate.min.css">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper/dist/css/swiper.min.css">
-  <script src="https://cdn.jsdelivr.net/npm/swiper/dist/js/swiper.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/swiper-animation@2.0.2/build/swiper-animation.min.js"></script>
+  <script src="https://unpkg.com/vue/dist/vue.js"></script>
+  <script src="https://unpkg.com/vuex/dist/vuex.js"></script>
+  <link rel="stylesheet" href="https://unpkg.com/animate.css@4.1.1/animate.min.css">
+  <link rel="stylesheet" href="https://unpkg.com/swiper/dist/css/swiper.min.css">
+  <script src="https://unpkg.com/swiper/dist/js/swiper.min.js"></script>
+  <script src="https://unpkg.com/swiper-animation@2.0.2/build/swiper-animation.min.js"></script>
   <!-- <script src="https://cdn.staticfile.org/echarts/4.3.0/echarts.min.js" async></script> -->
-  <script src="https://cdn.jsdelivr.net/npm/echarts/dist/echarts.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/v-charts/lib/index.min.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/v-charts/lib/style.min.css">
+  <script src="https://unpkg.com/echarts/dist/echarts.min.js"></script>
+  <script src="https://unpkg.com/v-charts/lib/index.min.js"></script>
+  <link rel="stylesheet" href="https://unpkg.com/v-charts/lib/style.min.css">
   <script>window.__work = <%- JSON.stringify(work) %></script>
   <script src="/engine-assets/engine.umd.js"></script>
   <style>
@@ -249,7 +249,7 @@
       }
 
       function doPCActions() {
-        loadJS('https://cdn.jsdelivr.net/npm/qrcode/build/qrcode.min.js', drawQRcode);
+        loadJS('https://unpkg.com/qrcode/build/qrcode.min.js', drawQRcode);
       }
 
       isMobile() ? doMobileActions() : doPCActions();

--- a/front-end/h5/public/index.html
+++ b/front-end/h5/public/index.html
@@ -30,11 +30,11 @@
       doc.setAttribute('data-useragent', navigator.userAgent);
     </script>
     <!-- <script src="https://code.createjs.com/1.0.0/createjs.min.js"></script> -->
-    <script src="https://cdn.jsdelivr.net/npm/createjs@1.0.1/builds/1.0.0/createjs.min.js" async></script>
+    <script src="https://unpkg.com/createjs@1.0.1/builds/1.0.0/createjs.min.js" async></script>
     <!-- <script src="https://cdn.staticfile.org/echarts/4.3.0/echarts.min.js" async></script> -->
-    <script src="https://cdn.jsdelivr.net/npm/echarts/dist/echarts.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/v-charts/lib/index.min.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/v-charts/lib/style.min.css">
+    <script src="https://unpkg.com/echarts/dist/echarts.min.js"></script>
+    <script src="https://unpkg.com/v-charts/lib/index.min.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/v-charts/lib/style.min.css">
     <script>
       // Note: 增加html userAgent标记，
       // windows启用下仿mac的滚动条样式。


### PR DESCRIPTION
Related to #430

Replace `cdn.jsdelivr.net` with `unpkg.com` in the project files to address the issue of unstable access to `cdn.jsdelivr.net`.

* **back-end/h5-api/views/engine.ejs**
  - Replace all instances of `cdn.jsdelivr.net` with `unpkg.com` for loading various scripts and stylesheets.
  - Update the QR code script source to use `unpkg.com`.

* **front-end/h5/public/index.html**
  - Replace all instances of `cdn.jsdelivr.net` with `unpkg.com` for loading various scripts and stylesheets.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ly525/luban-h5/issues/430?shareId=cdf271c3-5ddd-4ec1-94d2-0cf8ce033d64).